### PR TITLE
Add Arduino BLE bridge example

### DIFF
--- a/arduino/BitChatBridge/BitChatBridge.ino
+++ b/arduino/BitChatBridge/BitChatBridge.ino
@@ -1,0 +1,66 @@
+#include <ArduinoBLE.h>
+
+// BitChat BLE UUIDs
+const char* serviceUUID = "F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C";
+const char* characteristicUUID = "A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D";
+
+BLEService chatService(serviceUUID);                       // BitChat mesh service
+BLECharacteristic chatCharacteristic(characteristicUUID,
+                                     BLERead | BLEWrite | BLENotify, 244);
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial);
+
+  if (!BLE.begin()) {
+    Serial.println("Starting BLE failed!");
+    while (1);
+  }
+
+  BLE.setLocalName("BitChatBridge");
+  BLE.setAdvertisedService(chatService);
+
+  chatService.addCharacteristic(chatCharacteristic);
+  BLE.addService(chatService);
+
+  chatCharacteristic.writeValue((uint8_t*)"", 0); // initialize
+
+  BLE.advertise();
+  Serial.println("BitChat bridge ready");
+}
+
+void loop() {
+  BLEDevice central = BLE.central();
+
+  if (central) {
+    Serial.print("Connected to ");
+    Serial.println(central.address());
+
+    while (central.connected()) {
+      if (chatCharacteristic.written()) {
+        int len = chatCharacteristic.valueLength();
+        uint8_t buffer[244];
+        chatCharacteristic.readValue(buffer, len);
+
+        Serial.print("Received ");
+        Serial.print(len);
+        Serial.print(" bytes: ");
+        for (int i = 0; i < len; i++) {
+          Serial.print(buffer[i], HEX);
+          Serial.print(' ');
+        }
+        Serial.println();
+
+        // Reply with simple user message (type 0x04)
+        const char* msg = "Hello from Arduino";
+        uint8_t packet[1 + 32];
+        packet[0] = 0x04; // MessageType.message
+        size_t msgLen = strlen(msg);
+        memcpy(packet + 1, msg, msgLen);
+        chatCharacteristic.writeValue(packet, msgLen + 1);
+      }
+    }
+
+    Serial.println("Disconnected");
+  }
+}

--- a/arduino/BitChatBridge/README.md
+++ b/arduino/BitChatBridge/README.md
@@ -1,0 +1,24 @@
+# BitChat Bridge (Arduino)
+
+This sketch demonstrates basic Bluetooth Low Energy communication with the BitChat mesh network.
+
+It exposes the same BLE service and characteristic UUIDs used by the BitChat app:
+
+- Service UUID: `F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C`
+- Characteristic UUID: `A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D`
+
+The example advertises as a peripheral. When a BitChat node connects and writes data to the characteristic, the sketch logs the message to the serial console and replies with a simple text message. The first byte of each packet is the BitChat message type (0x04 for user messages).
+
+## Hardware
+
+Any Arduino board with BLE support (e.g., Nano 33 BLE, ESP32 running Arduino core).
+
+## Usage
+
+1. Compile and upload `BitChatBridge.ino` to your board.
+2. Open the serial monitor at 115200 baud.
+3. Launch BitChat and ensure Bluetooth is enabled.
+4. The app should discover the Arduino node as another peer.
+5. Messages sent from the app will appear in the serial monitor; the sketch sends back a greeting.
+
+This is a minimal example—real integration would implement the full BitChat binary protocol for routing and encryption.


### PR DESCRIPTION
## Summary
- add example Arduino sketch exposing BitChat BLE UUIDs
- document how to use the Arduino bridge

## Testing
- `swift test` *(fails: Failed to clone repository `https://github.com/21-DOT-DEV/swift-secp256k1/`)*
- `arduino-cli compile arduino/BitChatBridge` *(fails: `arduino-cli` not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ecf34955c832c83ef1085cec706a5